### PR TITLE
Add music test option to main menu

### DIFF
--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -73,7 +73,12 @@ wAudioSavedROMBank:: db
 wFrequencyModifier:: db
 wTempoModifier:: db
 
-	ds 13
+        ds 8
+
+wMusicTestReturnSong:: db
+wMusicTestReturnBank:: db
+wMusicTestTrackIndex:: db
+wMusicTestDisplayValue:: dw
 
 
 SECTION "Sprite State Data", WRAM0


### PR DESCRIPTION
## Summary
- add a Music Test entry to the main menu and wire it to a new screen
- implement the music test menu so the d-pad cycles through every track and A replays the current song
- track the menu selection and music state with new WRAM variables and a compact table of track ids

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68ccabf74bec8332928ca0a38f9b2617